### PR TITLE
Remove cdefs strings from build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8
-	flake8 pangocairocffi tests --exclude pangocairocffi/_generated/ffi.py,pangocairocffi/ffi_build.py
-	flake8 --ignore=W293 pangocairocffi/ffi_build.py
+	flake8 pangocairocffi tests --exclude pangocairocffi/_generated/ffi.py
 
 tests: ## run tests quickly with the default Python
 	python setup.py test

--- a/pangocairocffi/cdefs_cairo.txt
+++ b/pangocairocffi/cdefs_cairo.txt
@@ -1,0 +1,4 @@
+typedef void cairo_t;
+typedef void cairo_font_type_t;
+typedef void cairo_scaled_font_t;
+typedef void cairo_font_options_t;

--- a/pangocairocffi/cdefs_pangocairo.txt
+++ b/pangocairocffi/cdefs_pangocairo.txt
@@ -1,0 +1,89 @@
+typedef ... PangoCairoFontMap;
+typedef ... PangoCairoFont;
+typedef void (* PangoCairoShapeRendererFunc) (
+    cairo_t *cr,
+    PangoAttrShape *attr,
+    gboolean do_path,
+    gpointer data
+);
+
+PangoFontMap * pango_cairo_font_map_get_default (void);
+void pango_cairo_font_map_set_default (PangoCairoFontMap *fontmap);
+PangoFontMap * pango_cairo_font_map_new (void);
+PangoFontMap * pango_cairo_font_map_new_for_font_type (
+    cairo_font_type_t fonttype
+);
+cairo_font_type_t pango_cairo_font_map_get_font_type (
+    PangoCairoFontMap *fontmap
+);
+void pango_cairo_font_map_set_resolution (
+    PangoCairoFontMap *fontmap,
+    double dpi
+);
+double pango_cairo_font_map_get_resolution (
+    PangoCairoFontMap *fontmap
+);
+PangoContext * pango_cairo_font_map_create_context (
+    PangoCairoFontMap *fontmap
+);
+cairo_scaled_font_t * pango_cairo_font_get_scaled_font (
+    PangoCairoFont *font
+);
+void pango_cairo_context_set_resolution (
+    PangoContext *context, double dpi
+);
+double pango_cairo_context_get_resolution (PangoContext *context);
+void pango_cairo_context_set_font_options (
+    PangoContext *context,
+    const cairo_font_options_t *options
+);
+const cairo_font_options_t * pango_cairo_context_get_font_options (
+    PangoContext *context
+);
+void pango_cairo_context_set_shape_renderer (
+    PangoContext *context,
+    PangoCairoShapeRendererFunc func,
+    gpointer data,
+    GDestroyNotify dnotify
+);
+PangoCairoShapeRendererFunc pango_cairo_context_get_shape_renderer (
+    PangoContext *context,
+    gpointer *data
+);
+PangoContext * pango_cairo_create_context (cairo_t *cr);
+void pango_cairo_update_context (cairo_t *cr, PangoContext *context);
+PangoLayout * pango_cairo_create_layout (cairo_t *cr);
+void pango_cairo_update_layout (cairo_t *cr, PangoLayout *layout);
+void pango_cairo_show_glyph_string (
+    cairo_t *cr,
+    PangoFont *font,
+    PangoGlyphString *glyphs
+);
+void pango_cairo_show_glyph_item (
+    cairo_t *cr,
+    const char *text,
+    PangoGlyphItem *glyph_item
+);
+void pango_cairo_show_layout_line (cairo_t *cr,PangoLayoutLine *line);
+void pango_cairo_show_layout (cairo_t *cr, PangoLayout *layout);
+void pango_cairo_show_error_underline (
+    cairo_t *cr,
+    double x,
+    double y,
+    double width,
+    double height
+);
+void pango_cairo_glyph_string_path (
+    cairo_t *cr,
+    PangoFont *font,
+    PangoGlyphString *glyphs
+);
+void pango_cairo_layout_line_path (cairo_t *cr, PangoLayoutLine *line);
+void pango_cairo_layout_path (cairo_t *cr, PangoLayout *layout);
+void pango_cairo_error_underline_path (
+    cairo_t *cr,
+    double x,
+    double y,
+    double width,
+    double height
+);

--- a/pangocairocffi/ffi_build.py
+++ b/pangocairocffi/ffi_build.py
@@ -16,111 +16,22 @@ sys.path.append(str(Path(__file__).parent))
 # Create an empty _generated folder if needed
 (Path(__file__).parent / '_generated').mkdir(exist_ok=True)
 
+# Read the CFFI definitions
+cdefs_cairo_file = open(str(Path(__file__).parent / 'cdefs_cairo.txt'), 'r')
+cdefs_cairo = cdefs_cairo_file.read()
+cdefs_pangocairo_file = open(
+    str(Path(__file__).parent / 'cdefs_pangocairo.txt'),
+    'r'
+)
+cdefs_pangocairo = cdefs_pangocairo_file.read()
+
 # cffi definitions, in the order outlined in:
 # https://developer.gnome.org/pango/stable/pango-Cairo-Rendering.html
 ffi = FFI()
 ffi.include(ffi_build.ffi)
 ffi.set_source('pangocairocffi._generated.ffi', None)
-ffi.cdef('''
-    /* === Cairo === */
-
-    typedef void cairo_t;
-    typedef void cairo_font_type_t;
-    typedef void cairo_scaled_font_t;
-    typedef void cairo_font_options_t;
-
-    /* === PangoCairo === */
-
-    typedef ... PangoCairoFontMap;
-    typedef ... PangoCairoFont;
-    typedef void (* PangoCairoShapeRendererFunc) (
-        cairo_t *cr,
-        PangoAttrShape *attr,
-        gboolean do_path,
-        gpointer data
-    );
-        
-    PangoFontMap * pango_cairo_font_map_get_default (void);
-    void pango_cairo_font_map_set_default (PangoCairoFontMap *fontmap);
-    PangoFontMap * pango_cairo_font_map_new (void);
-    PangoFontMap * pango_cairo_font_map_new_for_font_type (
-        cairo_font_type_t fonttype
-    );
-    cairo_font_type_t pango_cairo_font_map_get_font_type (
-        PangoCairoFontMap *fontmap
-    );
-    void pango_cairo_font_map_set_resolution (
-        PangoCairoFontMap *fontmap,
-        double dpi
-    );
-    double pango_cairo_font_map_get_resolution (
-        PangoCairoFontMap *fontmap
-    );
-    PangoContext * pango_cairo_font_map_create_context (
-        PangoCairoFontMap *fontmap
-    );
-    cairo_scaled_font_t * pango_cairo_font_get_scaled_font (
-        PangoCairoFont *font
-    );
-    void pango_cairo_context_set_resolution (
-        PangoContext *context, double dpi
-    );
-    double pango_cairo_context_get_resolution (PangoContext *context);
-    void pango_cairo_context_set_font_options (
-        PangoContext *context,
-        const cairo_font_options_t *options
-    );
-    const cairo_font_options_t * pango_cairo_context_get_font_options (
-        PangoContext *context
-    );
-    void pango_cairo_context_set_shape_renderer (
-        PangoContext *context,
-        PangoCairoShapeRendererFunc func,
-        gpointer data,
-        GDestroyNotify dnotify
-    );
-    PangoCairoShapeRendererFunc pango_cairo_context_get_shape_renderer (
-        PangoContext *context,
-        gpointer *data
-    );
-    PangoContext * pango_cairo_create_context (cairo_t *cr);
-    void pango_cairo_update_context (cairo_t *cr, PangoContext *context);
-    PangoLayout * pango_cairo_create_layout (cairo_t *cr);
-    void pango_cairo_update_layout (cairo_t *cr, PangoLayout *layout);
-    void pango_cairo_show_glyph_string (
-        cairo_t *cr,
-        PangoFont *font,
-        PangoGlyphString *glyphs
-    );
-    void pango_cairo_show_glyph_item (
-        cairo_t *cr,
-        const char *text,
-        PangoGlyphItem *glyph_item
-    );
-    void pango_cairo_show_layout_line (cairo_t *cr,PangoLayoutLine *line);
-    void pango_cairo_show_layout (cairo_t *cr, PangoLayout *layout);
-    void pango_cairo_show_error_underline (
-        cairo_t *cr,
-        double x,
-        double y,
-        double width,
-        double height
-    );
-    void pango_cairo_glyph_string_path (
-        cairo_t *cr,
-        PangoFont *font,
-        PangoGlyphString *glyphs
-    );
-    void pango_cairo_layout_line_path (cairo_t *cr, PangoLayoutLine *line);
-    void pango_cairo_layout_path (cairo_t *cr, PangoLayout *layout);
-    void pango_cairo_error_underline_path (
-        cairo_t *cr,
-        double x,
-        double y,
-        double width,
-        double height
-    );
-''')
+ffi.cdef(cdefs_cairo)
+ffi.cdef(cdefs_pangocairo)
 
 if __name__ == '__main__':
     ffi.compile()

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 python_requires = >= 3.5
 
 [options.package_data]
-pangocairocffi = VERSION
+pangocairocffi = VERSION, *.txt
 
 [options.packages.find]
 exclude = pangocairocffi._generated


### PR DESCRIPTION
Storing massive text files in a python script is ugly and often causes linting issues because of line lengths.

This change moves the C-Definitions outside of `ffi_build.py` into two separate text file. One for cairo, and another for pangocairo.

The `makefile` has also been updated to not exclude this one file for linting.