### PR TITLE
Fix install issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ project_urls =
 packages = find:
 setup_requires =
   cffi >= 1.1.0
+  pangocffi >= 0.4.0
   setuptools
 install_requires =
   cffi >= 1.1.0


### PR DESCRIPTION
The are still issues when attempting to install and load this library outside of this repo.

* `pangocffi` needs to be part of the setup (as it it used in the build step when installing from pip I believe)
* The `ffi_pango.py` file also needs to be installed in the correct location on build. Depending on whether this module is being built or not, the file will either be installed in the `build/lib` directory, or directly in the source directory. It's essentially a hack on top of another hack 😬.
* Renamed some variables along the way for clarity.

Note: Since we have now added conditional logic in the build script, this will lower the code coverage