### PR TITLE
Fix library names for Win64 install

### DIFF
--- a/pangocairocffi/__init__.py
+++ b/pangocairocffi/__init__.py
@@ -26,7 +26,7 @@ def _dlopen(generated_ffi, *names):
     raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
 
 
-pangocairo = _dlopen(ffi, 'pangocairo-1.0')
+pangocairo = _dlopen(ffi, 'pangocairo-1.0', 'pangocairo-1.0-0')
 
 
 # Imports are normally always put at the top of the file.


### PR DESCRIPTION
See corresponding changes in pangocffi pull request 13