### PR TITLE
setup.py: indicating pangocffi directly in the setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,5 +41,8 @@ python_requires = >= 3.5
 include_package_data = True
 zip_safe = False
 
+[options.packages.find]
+exclude = pangocairocffi._generated, tests
+
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,10 @@ from setuptools import setup
 
 if sys.version_info.major < 3:
     raise RuntimeError(
-        'pangocairocffi does not support Python 2.x. Please use Python 3.'
+        "pangocairocffi does not support Python 2.x. Please use Python 3."
     )
 
 setup(
-    setup_requires=['pytest-runner'],
-    cffi_modules=[
-        'pangocairocffi/ffi_build.py:ffi'
-    ]
+    setup_requires=["pytest-runner", "pangocffi >= 0.4.0"],
+    cffi_modules=["pangocairocffi/ffi_build.py:ffi"],
 )


### PR DESCRIPTION
For a reason I still cannot fully explain, this solves the package installation order when installing with `pip` and from SCM.

It seems to me that the `setup.cfg` is interpreted later than the `setup.py`. When installing a requirement file containing this:

```
git+https://github.com/raffienficiaud/pangocffi.git@feature/various-api-support#egg=pangocffi
pangocairocffi==0.3.0
```

where there is a setup dependence from `pangocairocffi` to `pangocffi`, `pip` starts by installing `pangocairocffi` and fails. 
With this change, the following requirement file works as expected (without it, it simply doesn't):

```
git+https://github.com/raffienficiaud/pangocffi.git@feature/various-api-support#egg=pangocffi
git+https://github.com/raffienficiaud/pangocairocffi.git@fixup-install#egg=pangocairocffi
```

TBH, I still haven't found a clear indication in `setuptools` explaining this behaviour and the order or precedence of `setup,py` over `setup.cfg`. The best I've found to fix this issue is to duplicate the `pangocffi` `setup_requires` directive from `setup.cfg` to `setup.py`.

The PR also prevents the installation of the test files. 