### PR TITLE
Call garbage collection for context and layout pangocffi objects

### DIFF
--- a/pangocairocffi/create_update_functions.py
+++ b/pangocairocffi/create_update_functions.py
@@ -22,7 +22,7 @@ def create_context(cairo_context: cairocffi.Context) -> pangocffi.Context:
     """
     cairo_t_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
     layout_pointer = pangocairo.pango_cairo_create_context(cairo_t_pointer)
-    return pangocffi.Context.from_pointer(layout_pointer)
+    return pangocffi.Context.from_pointer(layout_pointer, gc=True)
 
 
 def update_context(
@@ -68,7 +68,7 @@ def create_layout(cairo_context: cairocffi.Context) -> pangocffi.Layout:
     """
     cairo_t_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
     layout_pointer = pangocairo.pango_cairo_create_layout(cairo_t_pointer)
-    return pangocffi.Layout.from_pointer(layout_pointer)
+    return pangocffi.Layout.from_pointer(layout_pointer, gc=True)
 
 
 def update_layout(

--- a/pangocairocffi/font_map.py
+++ b/pangocairocffi/font_map.py
@@ -137,4 +137,4 @@ class PangoCairoFontMap:
         context_pointer = pango.pango_font_map_create_context(
             self.get_pointer()
         )
-        return Context.from_pointer(context_pointer)
+        return Context.from_pointer(context_pointer, gc=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
 install_requires =
   cffi >= 1.1.0
   cairocffi >= 1.0.2
-  pangocffi >= 0.8.0
+  pangocffi >= 0.10.0
 python_requires = >= 3.6
 
 [options.package_data]


### PR DESCRIPTION
This depends on https://github.com/leifgehrmann/pangocffi/pull/36 being released.