### PR TITLE
Documentation: Remove unnecessary code, fix deprecated config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,49 +2,28 @@ from pathlib import Path
 import sys
 import os
 
-from unittest.mock import MagicMock, Mock
-
-generated_file = Path(__file__).parent.parent / 'pangocairocffi/_generated/ffi.py'
-if not os.path.exists(generated_file):
-    class AttrMock(MagicMock):
-        @classmethod
-        def __getattr__(cls, name):
-            if name == '_mock_methods' \
-                    or name == '__qualname__' \
-                    or name == '__args__':
-                # noinspection PyUnresolvedReferences
-                return super.__getattr__(cls, name)
-            else:
-                mm = AttrMock()
-            mm.__repr__ = lambda s: ("pangocairocffi.ffi." + name)
-            mm.__str__ = Mock(return_value=("pangocairocffi.ffi." + name))
-            return mm
-
-
-    class ModuleMock(MagicMock):
-        @classmethod
-        def __getattr__(cls, name):
-            mm = AttrMock()
-            return mm
-
-
-    MOCK_MODULES = ['pangocairocffi._generated', 'pangocairocffi._generated.ffi']
-    sys.modules.update((mod_name, ModuleMock()) for mod_name in MOCK_MODULES)
 
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.coverage']
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.coverage',
+]
 master_doc = 'index'
 project = 'pangocairocffi'
 copyright = '2019, Leif Gehrmann'
-release = (Path(__file__).parent.parent / 'pangocairocffi' / 'VERSION').read_text().strip()
+release = (Path(__file__).parent.parent / 'pangocairocffi' / 'VERSION')
+release = release.read_text().strip()
 version = '.'.join(release.split('.')[:2])
 exclude_patterns = ['_build']
 autodoc_member_order = 'bysource'
-autodoc_default_flags = ['members']
+autodoc_default_options = {
+    'members': None  # Set to True when readthedocs.org updates sphinx to v2.0
+}
 intersphinx_mapping = {
     'http://docs.python.org/': None,
-    'http://cairographics.org/documentation/pycairo/2/': None}
+    'https://pycairo.readthedocs.io/en/latest/': None,
+}
 
 sys.path.insert(0, os.path.abspath('..'))
 
-html_theme = "sphinx_rtd_theme"
+html_theme = 'sphinx_rtd_theme'


### PR DESCRIPTION
This PR does 2 things:

* Simplify the config by removing the mocking of pangocairocffi._generated and pangocariocffi._generated.ffi. This is no longer needed since we moved the generation of the FFI module to happen at runtime: #17.
* Replaced the deprecated autodoc_default_flags configuration value to autodoc_default_options.