### PR TITLE
Implement get/set_default() for PangoCairoFontMap + Documentation clarification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-all: clean ## run tests on all minor python versions
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	coverage run --source pangocffi -m pytest
+	coverage run --source pangocairocffi -m pytest
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ release = release.read_text().strip()
 version = '.'.join(release.split('.')[:2])
 exclude_patterns = ['_build']
 autodoc_member_order = 'bysource'
+autoclass_content = 'both'
 autodoc_default_options = {
     'members': None  # Set to True when readthedocs.org updates sphinx to v2.0
 }

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -28,13 +28,13 @@ ____________________________
 
 .. .. autofunction:: pangocairocffi.show_glyph_string
 
-.. .. autofunction:: pangocairocffi.show_glyph_item
-
 .. .. autofunction:: pangocairocffi.show_layout_line
 
 .. autofunction:: pangocairocffi.show_layout
 
 .. autofunction:: pangocairocffi.show_error_underline
+
+.. autofunction:: pangocairocffi.show_glyph_item
 
 Adding text to cairo's current path
 ___________________________________
@@ -50,7 +50,7 @@ ___________________________________
 PangoCairo Fonts
 ================
 
-PangoCairo Fonts Functions
+PangoCairo Font Functions
 __________________________
 
 .. .. autofunction:: pangocairocffi.get_cairo_scaled_font_pointer
@@ -63,7 +63,7 @@ __________________________
 
 .. autofunction:: pangocairocffi.get_font_options
 
-PangoCairo Fonts Map
+PangoCairo Font Map
 ____________________
 
 .. autoclass:: pangocairocffi.PangoCairoFontMap

--- a/pangocairocffi/render_functions.py
+++ b/pangocairocffi/render_functions.py
@@ -51,10 +51,9 @@ def show_glyph_item(
     :param cairo_context:
         a Cairo context
     :param text:
-        the UTF-8 text that :param:`glyph_item` refers to
+        the UTF-8 text that ``glyph_item`` refers to
     :param glyph_item:
         a Pango glyph item
-    :return:
     """
     cairo_context_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
     text_pointer = ffi.new('char[]', text.encode('utf8'))

--- a/tests/test_font_map.py
+++ b/tests/test_font_map.py
@@ -1,0 +1,16 @@
+from pangocairocffi import PangoCairoFontMap
+
+
+def test_font_map():
+    font_map_default = PangoCairoFontMap.get_default()
+    font_map_new = PangoCairoFontMap()
+    assert font_map_new != font_map_default
+
+    resolution = font_map_new.get_resolution()
+    assert resolution == 96
+    font_map_new.set_resolution(123)
+    assert font_map_new.get_resolution() == 123
+
+    PangoCairoFontMap.set_default(font_map_new)
+    assert font_map_new == PangoCairoFontMap.get_default()
+    PangoCairoFontMap.set_default(None)


### PR DESCRIPTION
This should resolve #25 

This PR implements `get_default()` and `set_default()` for `PangoCairoFontMap`. I don't believe there's much practical use of these methods yet, since the base class `FontMap` hasn't been implemented in `pangocffi` yet. Tests have been added for these methods, so code coverage will go up a fair bit.

This PR also:

* Adds `show_glyph_item()` as a rendering method, and fixes a few issues in the docstring
* Modified the documentation to show the `__init__` text for `PangoCairoFontMap`
* Some small adjustments to the documentation.
* Fixes a mistake in the makefile for running coverage on pangocairocffi