### PR TITLE
Split linting into a separate GitHub Action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,16 +7,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -27,6 +24,6 @@ jobs:
           coverage report -m
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run linting
+        run: |
+          make lint

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,4 @@ python =
 passenv = TOXENV CI
 deps = -rrequirements.txt
 commands =
-    flake8 pangocairocffi tests --exclude pangocairocffi/_generated/ffi.py
     coverage run --source pangocairocffi -m pytest -s


### PR DESCRIPTION
Currently there is one GitHub Action called build.yml that handles the linting and tests in one stage. It's a little bit annoying that linting blocks the running of tests if any of the files are not formatted correctly.

This PR splits the linting part of the workflow into lint.yml so that linting is executed in a separate workflow from tests.

This PR also upgrades the versions of the dependencies used in the workflows.