### PR TITLE
Support pangocffi v0.11.0 + Use `property()` for setting resolution

### DIFF
--- a/pangocairocffi/create_update_functions.py
+++ b/pangocairocffi/create_update_functions.py
@@ -43,7 +43,7 @@ def update_context(
     cairo_t_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
     pangocairo.pango_cairo_update_context(
         cairo_t_pointer,
-        pango_context.get_pointer()
+        pango_context.pointer
     )
 
 
@@ -86,4 +86,4 @@ def update_layout(
         a Pango layout
     """
     cairo_t_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
-    pangocairo.pango_cairo_update_layout(cairo_t_pointer, layout.get_pointer())
+    pangocairo.pango_cairo_update_layout(cairo_t_pointer, layout.pointer)

--- a/pangocairocffi/font_functions.py
+++ b/pangocairocffi/font_functions.py
@@ -32,7 +32,7 @@ def set_resolution(context: Context, dpi: float) -> None:
         involved; the terminology is conventional.) A 0 or negative value
         means to use the resolution from the font map.
     """
-    pangocairo.pango_cairo_context_set_resolution(context.get_pointer(), dpi)
+    pangocairo.pango_cairo_context_set_resolution(context.pointer, dpi)
 
 
 def get_resolution(context: Context) -> float:
@@ -45,7 +45,7 @@ def get_resolution(context: Context) -> float:
         the resolution in "dots per inch". A negative value will be returned
         if no resolution has previously been set.
     """
-    return pangocairo.pango_cairo_context_get_resolution(context.get_pointer())
+    return pangocairo.pango_cairo_context_get_resolution(context.pointer)
 
 
 def set_font_options(
@@ -65,7 +65,7 @@ def set_font_options(
     """
     if options is None:
         options = ffi.NULL
-    context_pointer = context.get_pointer()
+    context_pointer = context.pointer
     pangocairo.pango_cairo_context_set_font_options(context_pointer, options)
 
 
@@ -82,7 +82,7 @@ def get_font_options(context: Context) -> Optional[ffi.CData]:
             a cairo_font_options_t pointer previously set on the context,
             otherwise ``None``.
     """
-    context_pointer = context.get_pointer()
+    context_pointer = context.pointer
     font_option_pointer = pangocairo.pango_cairo_context_get_font_options(
         context_pointer
     )

--- a/pangocairocffi/render_functions.py
+++ b/pangocairocffi/render_functions.py
@@ -60,7 +60,7 @@ def show_glyph_item(
     pangocairo.pango_cairo_show_glyph_item(
         cairo_context_pointer,
         text_pointer,
-        glyph_item.get_pointer()
+        glyph_item.pointer
     )
 
 
@@ -102,7 +102,7 @@ def show_layout(
     cairo_context_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
     pangocairo.pango_cairo_show_layout(
         cairo_context_pointer,
-        layout.get_pointer()
+        layout.pointer
     )
 
 
@@ -206,7 +206,7 @@ def layout_path(
     cairo_context_pointer = _get_cairo_t_from_cairo_ctx(cairo_context)
     pangocairo.pango_cairo_layout_path(
         cairo_context_pointer,
-        layout.get_pointer()
+        layout.pointer
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cffi >= 1.1.0
 cairocffi >= 1.0.2
-pangocffi >= 0.8.0
+pangocffi >= 0.11.0
 flake8
 coverage
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ setup_requires =
 install_requires =
   cffi >= 1.1.0
   cairocffi >= 1.0.2
-  pangocffi >= 0.10.0
+  pangocffi >= 0.11.0
 python_requires = >= 3.6
 
 [options.package_data]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -13,9 +13,9 @@ def test_pdf():
     context.rotate(-0.1)
 
     layout = pangocairocffi.create_layout(context)
-    layout.set_width(pangocffi.units_from_double(width))
-    layout.set_alignment(pangocffi.Alignment.CENTER)
-    layout.set_markup('<span font="italic 30">Hi from Παν語</span>')
+    layout.width = pangocffi.units_from_double(width)
+    layout.alignment = pangocffi.Alignment.CENTER
+    layout.apply_markup('<span font="italic 30">Hi from Παν語</span>')
 
     pangocairocffi.show_layout(context, layout)
 

--- a/tests/test_error_underline.py
+++ b/tests/test_error_underline.py
@@ -22,9 +22,9 @@ def test_pdf():
     ctx = cairocffi.Context(surface)
 
     layout = pangocairocffi.create_layout(ctx)
-    layout.set_width(pangocffi.units_from_double(width))
-    layout.set_alignment(pangocffi.Alignment.CENTER)
-    layout.set_markup('Hi from Παν語')
+    layout.width = pangocffi.units_from_double(width)
+    layout.alignment = pangocffi.Alignment.CENTER
+    layout.apply_markup('Hi from Παν語')
 
     layout_logical_extent = layout.get_extents()[1]
     layout_baseline = pangocffi.units_to_double(layout.get_baseline())

--- a/tests/test_extents.py
+++ b/tests/test_extents.py
@@ -362,8 +362,8 @@ def test_pdf():
     layout.width = pangocffi.units_from_double(width / 2)
     layout.alignment = pangocffi.Alignment.CENTER
     layout.apply_markup('<span font="italic 30">Hi from Παν語</span>\n'
-                      'The text layout engine library for displaying '
-                      '<span font-weight="bold">multi-language</span> text!')
+                        'The text layout engine library for displaying '
+                        '<span font-weight="bold">multi-language</span> text!')
 
     translate_y = 110
     label_pos = (-width / 2 + 30, 30)

--- a/tests/test_extents.py
+++ b/tests/test_extents.py
@@ -343,9 +343,9 @@ def _show_label(
 ):
     context.translate(position[0], position[1])
     label = pangocairocffi.create_layout(context)
-    label.set_width(pangocffi.units_from_double(width))
-    label.set_alignment(pangocffi.Alignment.LEFT)
-    label.set_markup('<span font-family="sans-serif">%s</span>' % text)
+    label.width = pangocffi.units_from_double(width)
+    label.alignment = pangocffi.Alignment.LEFT
+    label.apply_markup('<span font-family="sans-serif">%s</span>' % text)
     pangocairocffi.show_layout(context, label)
     context.translate(-position[0], -position[1])
 
@@ -359,9 +359,9 @@ def test_pdf():
     ctx.translate(width / 2, 10)
 
     layout = pangocairocffi.create_layout(ctx)
-    layout.set_width(pangocffi.units_from_double(width / 2))
-    layout.set_alignment(pangocffi.Alignment.CENTER)
-    layout.set_markup('<span font="italic 30">Hi from Παν語</span>\n'
+    layout.width = pangocffi.units_from_double(width / 2)
+    layout.alignment = pangocffi.Alignment.CENTER
+    layout.apply_markup('<span font="italic 30">Hi from Παν語</span>\n'
                       'The text layout engine library for displaying '
                       '<span font-weight="bold">multi-language</span> text!')
 

--- a/tests/test_font_map.py
+++ b/tests/test_font_map.py
@@ -6,10 +6,10 @@ def test_font_map():
     font_map_new = PangoCairoFontMap()
     assert font_map_new != font_map_default
 
-    resolution = font_map_new.get_resolution()
+    resolution = font_map_new.resolution
     assert resolution == 96
-    font_map_new.set_resolution(123)
-    assert font_map_new.get_resolution() == 123
+    font_map_new.resolution = 123
+    assert font_map_new.resolution == 123
 
     PangoCairoFontMap.set_default(font_map_new)
     assert font_map_new == PangoCairoFontMap.get_default()

--- a/tests/test_glyph_item.py
+++ b/tests/test_glyph_item.py
@@ -18,7 +18,7 @@ def render_run_glyph_items(
         a Pango layout
     """
     layout_iter = layout.get_iter()
-    layout_text = layout.get_text()
+    layout_text = layout.text
 
     alternate = False
     while True:
@@ -119,7 +119,7 @@ def render_cluster_glyph_items(
     """
     layout_run_iter = layout.get_iter()
     layout_cluster_iter = layout.get_iter()
-    layout_text = layout.get_text()
+    layout_text = layout.text
 
     alternate = False
     while True:
@@ -164,9 +164,9 @@ def test_pdf():
     ctx.translate(width / 4, 100)
 
     layout = pangocairocffi.create_layout(ctx)
-    layout.set_width(pangocffi.units_from_double(width / 2))
-    layout.set_alignment(pangocffi.Alignment.CENTER)
-    layout.set_markup(
+    layout.width = pangocffi.units_from_double(width / 2)
+    layout.alignment = pangocffi.Alignment.CENTER
+    layout.apply_markup(
         '<span font="italic 30">Hi from Παν語</span>\n'
         '<span font="sans-serif">The text layout engine library for '
         'displaying <span font-weight="bold">multi-language</span> text!\n'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 [gh-actions]
 python =


### PR DESCRIPTION
Changes in `pangocffi` v0.11.0 are expected that will change a lot of the API calls to use `property()` pattern. See https://github.com/leifgehrmann/pangocffi/pull/47

This PR updates the dependency version and API calls to support the new notation.

This PR also:

* Updates the `FontMap`'s `resolution` to use the `property()` pattern as well.
* Updates `tox.ini` to include `py310`.