### PR TITLE
Drop support for Python 3.6 and 3.7 + Upgrade dependencies in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -26,7 +26,7 @@ Install with pip_::
 
 .. _pip: https://pip.pypa.io/
 
-Note: Python versions < 3.6 are not supported.
+Note: Python versions < 3.8 are not supported.
 
 Importing pangocairocffi
 ------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ classifiers =
   Intended Audience :: Developers
   Natural Language :: English
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.6
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
   Topic :: Multimedia :: Graphics
   Topic :: Text Processing :: Fonts
 project_urls =
@@ -37,7 +37,7 @@ install_requires =
   cffi >= 1.1.0
   cairocffi >= 1.0.2
   pangocffi >= 0.11.0
-python_requires = >= 3.6
+python_requires = >= 3.8
 
 [options.package_data]
 pangocairocffi = VERSION, *.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py312
-    3.12: py313
+    3.11: py311
+    3.12: py312
 
 [testenv]
 passenv = TOXENV,CI

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py38, py39, py310, py311, py312
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py312
+    3.12: py313
 
 [testenv]
 passenv = TOXENV CI

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.12: py313
 
 [testenv]
-passenv = TOXENV CI
+passenv = TOXENV,CI
 deps = -rrequirements.txt
 commands =
     coverage run --source pangocairocffi -m pytest -s


### PR DESCRIPTION
* Fixed an issue with `tox.ini`. Evidently [in 4.0.6, a breaking change was added](https://tox.wiki/en/4.11.3/changelog.html#features-4-0-6) that requires commas between environment variables. The error was this: `pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'TOXENV CI'`
* Python 3.6 and 3.7 are [end-of-life](https://endoflife.date/python), so in the next release of pangocairocffi we will announce that these versions are no longer supported. This includes the following changes:
  * Removing Python 3.6 and 3.7 from `setup.cfg`.
  * Removing Python 3.6 and 3.7 from the `build.yml` action.
* In theory we should also support 3.11 and 3.12, so the following changes were made:
  * `setup.cfg` has been updated to show that the package supports 3.11 and 3.12.
  * Updated the documentation to explicitly say what versions of python we support.
  * `coverage.yml` and `lint.yml` actions have been updated to use the latest version of python, 3.12.
* This PR will also update the use of `actions/checkout` in the GitHub actions to version 4.