### PR TITLE
Fix GitHub actions (Codecov + macOS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,11 @@ jobs:
           brew install libffi
           brew install pango
           brew install glib
+          # https://github.com/Kozea/CairoSVG/issues/354#issuecomment-1160552256
+          sudo ln -s /opt/homebrew/lib/libcairo* .
+          sudo ln -s /opt/homebrew/lib/libpango* .
+          sudo ln -s /opt/homebrew/lib/libgobject* .
+          sudo ln -s /opt/homebrew/lib/libglib* .
       - name: Install System Dependencies (Windows)
         if: runner.os == 'windows'
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,7 @@ jobs:
           coverage report -m
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This issue is similar to: https://github.com/leifgehrmann/pangocffi/pull/57

The GitHub actions are failing again. This is due to two issues:

* v3 of `codecov-actions` is no longer supported. It's an almost seamless upgrade to v4, but it now requires a token called `CODECOV_TOKEN`, which I've added to this repository.
* In recent versions of macOS (I suspect macs with M-series chips), homebrew places libraries like pango and cairo in unexpected locations that cause the tests for pangocairocffi to fail to load the library. Users of cairocffi faced similar issues (which I've linked in the yaml) and was solved by creating a symbolic link between the libraries and the pangocairocffi directory. Unsure if this is the _right_ thing to do, but it works, and this is only done for the GitHub action, it's not used anywhere else critical. For reference, the error below is what happens if the library cannot be located.

```
 >       raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
  E       OSError: dlopen() failed to load a library: cairo / cairo-2 / cairo-gobject-2 / cairo.so.2
```