### PR TITLE
Add deprecation notice and fix doc generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Build Status](https://github.com/leifgehrmann/pangocairocffi/actions/workflows/build.yml/badge.svg)](https://github.com/leifgehrmann/pangocairocffi/actions)
 [![Documentation Status](https://readthedocs.org/projects/pangocairocffi/badge/?version=latest)](https://pangocairocffi.readthedocs.io/en/latest/?badge=latest)
 
+**Deprecation Notice:** pangocffi and pangocairocffi are no longer being maintained. There are no plans to officially handover ownership of the project to another maintainer. PyGObject can be used as a replacement, but will also require migrating from cairocffi to pycairo. For more information, please see the [PyGObject Migration Guide](https://pangocffi.readthedocs.io/en/latest/migration-guide.html).
+
 pangocairocffi is a [CFFI]-based set of Python bindings for the
 [cairo rendering methods with pango]. It is meant to be used in
 conjunction with [cairocffi] and [pangocffi].

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,27 +4,22 @@ import os
 
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.coverage',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.coverage",
 ]
-master_doc = 'index'
-project = 'pangocairocffi'
-copyright = '2019, Leif Gehrmann'
-release = (Path(__file__).parent.parent / 'pangocairocffi' / 'VERSION')
+master_doc = "index"
+project = "pangocairocffi"
+copyright = "2019, Leif Gehrmann"
+release = (Path(__file__).parent.parent / "pangocairocffi" / "VERSION")
 release = release.read_text().strip()
-version = '.'.join(release.split('.')[:2])
-exclude_patterns = ['_build']
-autodoc_member_order = 'bysource'
-autoclass_content = 'both'
+version = ".".join(release.split(".")[:2])
+exclude_patterns = ["_build"]
+autodoc_member_order = "bysource"
 autodoc_default_options = {
     'members': None  # Set to True when readthedocs.org updates sphinx to v2.0
 }
-intersphinx_mapping = {
-    'http://docs.python.org/': None,
-    'https://pycairo.readthedocs.io/en/latest/': None,
-}
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,6 +1,13 @@
 Overview
 ========
 
+**Deprecation Notice:** pangocffi and pangocairocffi are no longer being maintained.
+There are no plans to officially handover ownership of the project to another maintainer.
+PyGObject can be used as a replacement, but will also require migrating from cairocffi to pycairo.
+For more information, please see the `PyGObject Migration Guide`_.
+
+.. _PyGObject Migration Guide: https://pangocffi.readthedocs.io/en/latest/migration-guide.html
+
 Installing
 ----------
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -33,7 +33,7 @@ Install with pip_::
 
 .. _pip: https://pip.pypa.io/
 
-Note: Python versions < 3.8 are not supported.
+Note: Python versions < 3.10 are not supported.
 
 Importing pangocairocffi
 ------------------------

--- a/docs/pangocairocffi.rst
+++ b/docs/pangocairocffi.rst
@@ -1,7 +1,13 @@
+**Deprecation Notice:** pangocffi and pangocairocffi are no longer being maintained.
+There are no plans to officially handover ownership of the project to another maintainer.
+PyGObject can be used as a replacement, but will also require migrating from cairocffi to pycairo.
+For more information, please see the `PyGObject Migration Guide`_.
+
 pangocairocffi is a `CFFI`_-based set of Python bindings for the
 `cairo rendering methods with pango`_. It is meant to be used in
 conjunction with cairocffi_ and pangocffi_.
 
+.. _PyGObject Migration Guide: https://pangocffi.readthedocs.io/en/latest/migration-guide.html
 .. _CFFI: https://cffi.readthedocs.org/
 .. _pangocffi: https://github.com/leifgehrmann/pangocffi
 .. _cairocffi: https://cairocffi.readthedocs.io/en/stable/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ cairocffi >= 1.0.2
 pangocffi >= 0.11.0
 flake8
 coverage
+sphinx
+sphinx_rtd_theme
 pytest
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ classifiers =
   Intended Audience :: Developers
   Natural Language :: English
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.8
-  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
   Topic :: Multimedia :: Graphics
   Topic :: Text Processing :: Fonts
 project_urls =
@@ -37,7 +37,7 @@ install_requires =
   cffi >= 1.1.0
   cairocffi >= 1.0.2
   pangocffi >= 0.11.0
-python_requires = >= 3.8
+python_requires = >= 3.10
 
 [options.package_data]
 pangocairocffi = VERSION, *.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py38, py39, py310, py311, py312
+envlist = py310, py311, py312, py313, py314
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 passenv = TOXENV,CI


### PR DESCRIPTION
See https://github.com/leifgehrmann/pangocffi/pull/66

This PR also:

* fixes the generation of documentation
* updates the minimum version of Python to be 3.10, to align with pangocffi
* verified support for Python 3.14 via tests